### PR TITLE
Fix for idleTimeout parameter of ConnectionSettings

### DIFF
--- a/src/main/kotlin/commons/configuration/ConnectionSettings.kt
+++ b/src/main/kotlin/commons/configuration/ConnectionSettings.kt
@@ -28,12 +28,19 @@ data class ConnectionSettings(
      */
     val connectionTimeout: Int = 100,
     /**
-     * The timeout in milliseconds to use when waiting for a response from the database
-     * or when the connection is idle.
+     * The timeout in milliseconds to use when waiting for a response from the database.
      *
-     * The default value is 30000.
+     * The default value is 2000.
      */
-    val idleTimeout: Int = 30000,
+    val socketTimeout: Int = 2000,
+    /**
+     * The number of seconds to wait before closing an idle connection.
+     *
+     * If the number is less than or equal to 0, the connection expires according to the default database settings.
+     *
+     * The default value is 30.
+     */
+    val idleTimeout: Int = 30,
     /**
      * The maximum number of connections to keep open at any one time.
      *
@@ -69,7 +76,7 @@ data class ConnectionSettings(
             .append("$host:$port/$database")
             .append("?characterEncoding=UTF-8&")
             .append("connectionTimeout=$connectionTimeout&")
-            .append("socketTimeout=$idleTimeout")
+            .append("socketTimeout=$socketTimeout")
 
         if (username != null) stringBuilder.append("&user=$username")
         if (password != null) stringBuilder.append("&password=$password")

--- a/src/test/kotlin/commons/configuration/ConnectionSettingsTest.kt
+++ b/src/test/kotlin/commons/configuration/ConnectionSettingsTest.kt
@@ -14,7 +14,7 @@ internal class ConnectionSettingsTest {
         )
 
         assertEquals("jdbc:mysql://localhost:3306/" +
-                "test?characterEncoding=UTF-8&connectionTimeout=100&socketTimeout=30000",
+                "test?characterEncoding=UTF-8&connectionTimeout=100&socketTimeout=2000",
             cs.toString())
     }
 
@@ -29,7 +29,7 @@ internal class ConnectionSettingsTest {
         )
 
         assertEquals("jdbc:mysql://localhost:3306/" +
-                "test?characterEncoding=UTF-8&connectionTimeout=100&socketTimeout=30000" +
+                "test?characterEncoding=UTF-8&connectionTimeout=100&socketTimeout=2000" +
                 "&user=user&password=pass",
             cs.toString())
     }

--- a/src/test/kotlin/habitat/RacoonManagerTest.kt
+++ b/src/test/kotlin/habitat/RacoonManagerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class RacoonManagerTest {
+    val verbose = false
 
     @BeforeEach
     fun setUp() {
@@ -92,6 +93,22 @@ internal class RacoonManagerTest {
             cat.name = "test2"
             it.update(cat)
             assertEquals("test2", it.find<Cat>(cat.id!!)!!.name)
+        }
+    }
+
+    @Test
+    fun timeout() {
+        var hash: Int? = null
+        RacoonDen.getManager().use { rm ->
+            hash = rm.connection.hashCode()
+            val cat = rm.find<Cat>(1)
+            if(verbose) println(cat?.name)
+        }
+        Thread.sleep(6000)
+        RacoonDen.getManager().use { rm ->
+            val cat = rm.find<Cat>(1)
+            if(verbose) println(cat?.name)
+            assertNotEquals(hash, rm.connection.hashCode())
         }
     }
 }


### PR DESCRIPTION
If a connection is idle for more that the specified time in the idleTimeout settings, the connection will be closed and when a new one is requested, a new one is created instead of the same one being used.

The old beaviour of the idleTimeout is replaced by the new property socketTimeout.