### PR TITLE
Added enum support

### DIFF
--- a/src/main/kotlin/habitat/configuration/RacoonConfiguration.kt
+++ b/src/main/kotlin/habitat/configuration/RacoonConfiguration.kt
@@ -2,6 +2,7 @@ package habitat.configuration
 
 import habitat.definition.LazyId
 import internals.casting.ParameterCaster
+import internals.casting.builtin.EnumCaster
 import internals.casting.builtin.LazyCaster
 import internals.configuration.ConnectionSettings
 import internals.mappers.NameMapper
@@ -58,7 +59,8 @@ object RacoonConfiguration {
 
     object Casting {
         private val parameterCasters: MutableMap<KClass<out Any>, ParameterCaster<out Any, out Any>> = mutableMapOf(
-            LazyId::class to LazyCaster()
+            LazyId::class to LazyCaster(),
+            Enum::class to EnumCaster()
         )
 
         fun <T: Any> setCaster(clazz: KClass<T>, caster: ParameterCaster<T, out Any>) {

--- a/src/main/kotlin/internals/casting/builtin/EnumCaster.kt
+++ b/src/main/kotlin/internals/casting/builtin/EnumCaster.kt
@@ -1,0 +1,38 @@
+package internals.casting.builtin
+
+import habitat.context.ParameterCasterContext
+import habitat.definition.ColumnName
+import internals.casting.ParameterCaster
+import kotlin.reflect.KClass
+
+class EnumCaster : ParameterCaster<Enum<*>, String> {
+    override fun toQuery(parameter: Enum<*>, context: ParameterCasterContext): String =
+        getNameFromEnum(parameter)
+
+    override fun fromQuery(parameter: String, context: ParameterCasterContext): Enum<*> =
+        getEnumFromName(parameter, context.actualType)
+
+    private companion object {
+        inline fun <reified T: Annotation> Array<Annotation>.findAnnotation(): T? =
+            find { it is T }?.let { it as T }
+
+        fun getNameFromEnum(enum: Enum<*>): String =
+            enum.declaringClass.fields
+                // Find the field with the same name as the enum value
+                .find { it.name == enum.name }?.let {
+                    // Find the ColumnName annotation on the field or return the field name
+                    it.annotations.findAnnotation<ColumnName>()?.name ?: it.name
+                }!!
+
+        fun getEnumFromName(name: String, kClass: KClass<*>) =
+            @Suppress("UPPER_BOUND_VIOLATED", "UNCHECKED_CAST")
+            java.lang.Enum.valueOf<Any>(kClass.java as Class<Any>, getEnumNameFromName(name, kClass)) as Enum<*>
+
+        fun getEnumNameFromName(name: String, kClass: KClass<*>) =
+            kClass.java.fields
+                .find { field ->
+                    field.annotations.findAnnotation<ColumnName>()?.
+                    let { it.name == name } ?: false || field.name == name
+                }?.name ?: throw IllegalArgumentException("No enum constant found for name $name")
+    }
+}

--- a/src/test/kotlin/internals/casting/builtin/EnumCasterTest.kt
+++ b/src/test/kotlin/internals/casting/builtin/EnumCasterTest.kt
@@ -1,0 +1,83 @@
+package internals.casting.builtin
+
+import habitat.RacoonDen
+import habitat.configuration.RacoonConfiguration
+import internals.configuration.ConnectionSettings
+import internals.mappers.NameMapper
+import models.Dog
+import models.DogColor
+import models.DogSize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class EnumCasterTest {
+    @BeforeEach
+    fun setUp() {
+        RacoonConfiguration.Connection.setDefault(
+            ConnectionSettings(
+                host = "localhost",
+                port = 3306,
+                database = "racoon-ktor-sample",
+                username = "admin",
+                password = "admin",
+                idleTimeout = 3
+            )
+        )
+        RacoonConfiguration.Naming.setTableNameMapper(NameMapper.lowerSnakeCase)
+    }
+
+    @Test
+    fun enumInsert() {
+        RacoonDen.getManager().use { rm ->
+            rm.insert(
+                Dog(
+                    name = "Star",
+                    size = DogSize.SMALL
+                )
+            )
+        }
+    }
+
+    @Test
+    fun enumInsertWithColumnName() {
+        RacoonDen.getManager().use { rm ->
+            rm.insert(
+                Dog(
+                    name = "Star",
+                    size = DogSize.L,
+                    color = DogColor.DARK
+                )
+            )
+        }
+    }
+
+    @Test
+    fun enumSelect() {
+        RacoonDen.getManager().use { rm ->
+            val dog = rm.insert(
+                Dog(
+                    name = "Star",
+                    size = DogSize.SMALL,
+                    color = DogColor.LIGHT
+                )
+            )
+            val dog2 = rm.find<Dog>(dog.id!!)
+            assertEquals(DogSize.SMALL, dog2!!.size)
+        }
+    }
+
+    @Test
+    fun enumSelectWithColumnName() {
+        RacoonDen.getManager().use { rm ->
+            val dog = rm.insert(
+                Dog(
+                    name = "Star",
+                    size = DogSize.L
+                )
+            )
+            val dog2 = rm.find<Dog>(dog.id!!)
+            assertEquals(DogSize.L, dog2!!.size)
+        }
+    }
+}

--- a/src/test/kotlin/models/Dog.kt
+++ b/src/test/kotlin/models/Dog.kt
@@ -1,0 +1,25 @@
+package models
+
+import habitat.definition.ColumnName
+import habitat.definition.Table
+
+enum class DogSize {
+    SMALL,
+    MEDIUM,
+    @ColumnName("LARGE")
+    L,
+    ;
+}
+
+enum class DogColor {
+    LIGHT,
+    DARK,
+    ;
+}
+
+class Dog (
+    override var id: Int? = null,
+    var name: String,
+    var size: DogSize,
+    var color: DogColor? = null
+) : Table

--- a/src/test/resources/mysql-restore.sql
+++ b/src/test/resources/mysql-restore.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS cat;
+DROP TABLE IF EXISTS dog;
 DROP TABLE IF EXISTS owner;
 
 CREATE TABLE owner
@@ -6,6 +7,14 @@ CREATE TABLE owner
     id      INT AUTO_INCREMENT PRIMARY KEY,
     name    VARCHAR(255) NULL,
     surname VARCHAR(255) NULL
+);
+
+CREATE TABLE dog
+(
+    id    INT AUTO_INCREMENT PRIMARY KEY,
+    name  VARCHAR(255)                      NULL,
+    size  ENUM ('SMALL', 'MEDIUM', 'LARGE') NOT NULL,
+    color ENUM ('LIGHT', 'DARK')            NULL
 );
 
 CREATE TABLE cat


### PR DESCRIPTION
A `Table` with an enum property can now be inserted and queried successfully. The annotation `ColumnName` also works with enum fields.