### PR TITLE
Fixed ambiguous null LazyId

### DIFF
--- a/src/main/kotlin/habitat/RacoonManager.kt
+++ b/src/main/kotlin/habitat/RacoonManager.kt
@@ -209,7 +209,7 @@ class RacoonManager(
     fun <T : Table> updateK(obj: T, kClass: KClass<T>) = obj.apply {
         val executeRacoon = createExecuteRacoon(generateUpdateQueryK(kClass))
         val parameters = kClass.memberProperties
-        for (field in parameters) executeRacoon.setParam(field.name, field.get(obj))
+        for (field in parameters) executeRacoon.setParam(ColumnName.getName(field), field.get(obj))
         executeRacoon.execute()
 
         obj.id?.let {

--- a/src/main/kotlin/habitat/definition/LazyId.kt
+++ b/src/main/kotlin/habitat/definition/LazyId.kt
@@ -6,21 +6,21 @@ import kotlin.reflect.KClass
 @Suppress("unused")
 class LazyId<T: Table> private constructor(
     val type: KClass<T>,
-    var id: Int?,
+    val id: Int?,
 
-    var manager: RacoonManager? = null,
+    val manager: RacoonManager? = null,
 
-    var value: T? = null,
+    var value: T?,
     var isLoaded: Boolean = false
 ) {
-    fun get(): T? {
+    fun get(): T {
         if (!isLoaded) {
-            val manager = manager ?: throw IllegalArgumentException("No manager available")
-            val id = id ?: throw IllegalArgumentException("No id available")
+            manager ?: throw IllegalArgumentException("No manager available")
+            id ?: throw IllegalArgumentException("No id available")
             value = manager.findK(id, type)
             isLoaded = true
         }
-        return value
+        return value ?: throw IllegalArgumentException("No value found of type ${type.simpleName} with id $id")
     }
 
     companion object {
@@ -29,8 +29,5 @@ class LazyId<T: Table> private constructor(
 
         inline fun <reified T : Table> defined(value: T) = defined(value, T::class)
         fun <T : Table> defined(value: T, type: KClass<T>) = LazyId(type, value.id, null, value, true)
-
-        inline fun <reified T: Table> empty() = empty(T::class)
-        fun <T: Table> empty(type: KClass<T>) = LazyId(type, null, null, null, true)
     }
 }

--- a/src/main/kotlin/habitat/racoons/QueryRacoon.kt
+++ b/src/main/kotlin/habitat/racoons/QueryRacoon.kt
@@ -149,11 +149,7 @@ class QueryRacoon(
 
                 var value: Any? = getResultSetValue(immutableResultSet, "$sqlAlias.$name") ?:
                     getResultSetValue(immutableResultSet, name)
-                ?: if (isLazy) {
-                    map[parameter] = LazyId.empty(kGeneric!!)
-                    continue@rsFor
-                }
-                else if (parameter.isMarkedNullable()) {
+                ?: if (parameter.isMarkedNullable()) {
                     map[parameter] = null
                     continue@rsFor
                 }

--- a/src/test/kotlin/habitat/RacoonManagerTest.kt
+++ b/src/test/kotlin/habitat/RacoonManagerTest.kt
@@ -34,7 +34,7 @@ internal class RacoonManagerTest {
             val cat = Cat(
                 name = "test",
                 age = 10,
-                owner_id = LazyId.empty()
+                owner_id = null
             )
             it.insert(cat)
             catId = cat.id
@@ -74,7 +74,7 @@ internal class RacoonManagerTest {
             val cat = Cat(
                 name = "test",
                 age = 10,
-                owner_id = LazyId.empty()
+                owner_id = null
             )
             it.insert(cat)
             it.delete(cat)
@@ -88,7 +88,7 @@ internal class RacoonManagerTest {
             val cat = Cat(
                 name = "test",
                 age = 10,
-                owner_id = LazyId.empty()
+                owner_id = null
             )
             it.insert(cat)
             cat.name = "test2"

--- a/src/test/kotlin/habitat/definition/LazyIdTest.kt
+++ b/src/test/kotlin/habitat/definition/LazyIdTest.kt
@@ -41,7 +41,7 @@ internal class LazyIdTest {
                 )
             )
 
-            assertNotNull(cat.owner_id.id)
+            assertNotNull(cat.owner_id?.id)
             assertNotNull(cat.id)
         }
     }
@@ -58,7 +58,7 @@ internal class LazyIdTest {
                 )
             )
 
-            assertNotNull(cat.owner_id.id)
+            assertNotNull(cat.owner_id?.id)
             assertNotNull(cat.id)
         }
     }
@@ -73,7 +73,7 @@ internal class LazyIdTest {
                 )
             )
 
-            assertNull(cat.owner_id.id)
+            assertNull(cat.owner_id?.id)
             assertNotNull(cat.id)
         }
     }
@@ -83,8 +83,8 @@ internal class LazyIdTest {
         RacoonDen.getManager().use { rm ->
             val cat = rm.find<Cat>(1)!!
 
-            assertNotNull(cat.owner_id.id)
-            assertNotNull(cat.owner_id.get())
+            assertNotNull(cat.owner_id?.id)
+            assertNotNull(cat.owner_id?.get())
             assertNotNull(cat.id)
         }
     }

--- a/src/test/kotlin/habitat/racoons/QueryRacoonTest.kt
+++ b/src/test/kotlin/habitat/racoons/QueryRacoonTest.kt
@@ -130,7 +130,7 @@ internal class QueryRacoonTest {
             }.toMutableList()
 
         cats.forEach {
-            val owner = it.owner_id.get()
+            val owner = it.owner_id?.get()
             if (verbose) println(owner)
         }
     }
@@ -210,7 +210,7 @@ internal class QueryRacoonTest {
             var NAME: String?,
             @property:ColumnName("owner_id")
             @param:ColumnName("owner_id")
-            var OWNERID: LazyId<Owner>,
+            var OWNERID: LazyId<Owner>? = null,
         ) : Table
 
         RacoonDen.getManager().use { rm ->

--- a/src/test/kotlin/internals/casting/ParameterCasterTest.kt
+++ b/src/test/kotlin/internals/casting/ParameterCasterTest.kt
@@ -30,7 +30,7 @@ internal class ParameterCasterTest {
         override var id: Int? = null,
         var age: Int2,
         var name: String?,
-        var owner_id: LazyId<Owner>,
+        var owner_id: LazyId<Owner>? = null,
     ) : Table
 
     companion object {
@@ -54,7 +54,7 @@ internal class ParameterCasterTest {
     @Test
     fun customParameterInsert() {
         RacoonDen.getManager().use { rm ->
-            val cat = Cat2(age = Int2(2), name = "cat", owner_id = LazyId.empty())
+            val cat = Cat2(age = Int2(2), name = "cat")
             rm.insert(cat)
 
             val ncat = rm.find<Cat2>(cat.id!!)

--- a/src/test/kotlin/models/Cat.kt
+++ b/src/test/kotlin/models/Cat.kt
@@ -7,5 +7,5 @@ class Cat(
     override var id: Int? = null,
     var age: Int,
     var name: String?,
-    var owner_id: LazyId<Owner> = LazyId.empty(),
+    var owner_id: LazyId<Owner>? = null
 ) : Table


### PR DESCRIPTION
The `LazyId` does not have an `empty` method anymore, and the `get` method cannot return a null value. If a property of a `Table` can be null, make the `LazyId` itself nullable.

A small fix of the `update` method is also included.