### PR TITLE
Added basic caches to RM functions

### DIFF
--- a/src/main/kotlin/habitat/RacoonManager.kt
+++ b/src/main/kotlin/habitat/RacoonManager.kt
@@ -40,7 +40,7 @@ class RacoonManager(
     var closed = false
         internal set
 
-    private val cache = RacoonCache()
+    internal val cache = RacoonCache()
 
     /**
      * Closes the connection to the database.
@@ -113,6 +113,7 @@ class RacoonManager(
         if (closed) throw connectionClosedException()
         if (!finalOpExecuted) throw IllegalStateException("Can't release before final operation has been executed")
         this.closed = true
+        this.cache.clean()
         RacoonDen.releaseManager(this)
     }
 
@@ -200,13 +201,13 @@ class RacoonManager(
     }
 
     /**
-     * Behaves like [insertK], but instead of passing the class as a normal parameter, it is passed as a reified type.
+     * Behaves like [insertUncachedK], but instead of passing the class as a normal parameter, it is passed as a reified type.
      *
      * @param T The type that is being inserted.
      * @param obj The object to insert.
      * @return The [RacoonManager] instance.
      */
-    inline fun <reified T : Table> insert(obj: T) = insertK(obj, T::class)
+    inline fun <reified T : Table> insertUncached(obj: T) = insertUncachedK(obj, T::class)
 
     /**
      * Inserts an object into the database and updates the id.
@@ -215,15 +216,36 @@ class RacoonManager(
      * @param kClass The class of the object to insert.
      * @return The object with the id updated. Any old reference to the object will still be valid.
      */
-    fun <T : Table> insertK(obj: T, kClass: KClass<T>) = obj.apply {
+    fun <T : Table> insertUncachedK(obj: T, kClass: KClass<T>) = obj.apply {
         val parameters = kClass.memberProperties
 
         createInsertRacoon(generateInsertQueryK(kClass)).use { insertRacoon ->
             for (field in parameters) insertRacoon.setParam(ColumnName.getName(field), field.get(obj))
             insertRacoon.execute()
             obj.id = insertRacoon.generatedKeys[0]
+
+            refreshK(obj, kClass)
         }
     }
+
+    /**
+     * Behaves like [insertK], but instead of passing the class as a normal parameter, it is passed as a reified type.
+     *
+     * @param T The type that is being inserted.
+     * @param obj The object to insert.
+     */
+    inline fun <reified T : Table> insert(obj: T) = insertK(obj, T::class)
+
+    /**
+     * Inserts an object into the database and updates the id.
+     *
+     * The inserted object is also inserted into the cache.
+     *
+     * @param obj The object to insert.
+     * @param kClass The class of the object to insert.
+     */
+    fun <T : Table> insertK(obj: T, kClass: KClass<T>) =
+        insertUncachedK(obj, kClass).also { cache.putK(obj, kClass) }
 
     /**
      * Behaves like [updateK], but instead of passing the class as a normal parameter, it is passed as a reified type.
@@ -232,7 +254,7 @@ class RacoonManager(
      * @param obj The object to update.
      * @return The [RacoonManager] instance.
      */
-    inline fun <reified T : Table> update(obj: T) = updateK(obj, T::class)
+    inline fun <reified T : Table> updateUncached(obj: T) = updateUncachedK(obj, T::class)
 
     /**
      * Updates a record in the database with the given object.
@@ -244,23 +266,39 @@ class RacoonManager(
      * @param kClass The class of the object to update.
      * @return The [RacoonManager] instance.
      */
-    fun <T : Table> updateK(obj: T, kClass: KClass<T>) = obj.apply {
+    fun <T : Table> updateUncachedK(obj: T, kClass: KClass<T>) = obj.apply {
         val parameters = kClass.memberProperties
 
         createExecuteRacoon(generateUpdateQueryK(kClass)).use { executeRacoon ->
             for (field in parameters) executeRacoon.setParam(ColumnName.getName(field), field.get(obj))
             executeRacoon.execute()
 
-            obj.id?.let {
-                val updated = findK(it, kClass) ?: throw SQLException("Could not find object with id '$it' " +
-                        "while updating the fields")
-
-                for (parameter in parameters) {
-                    if (parameter !is KMutableProperty<*>) continue
-                    parameter.setter.call(obj, getValueK(updated, parameter.name, kClass))
-                }
-            }
+            refreshK(obj, kClass)
         }
+    }
+
+    /**
+     * Behaves like [updateK], but instead of passing the class as a normal parameter, it is passed as a reified type.
+     *
+     * @param T The type that is being updated.
+     * @param obj The object to update.
+     */
+    inline fun <reified T : Table> update(obj: T) = updateK(obj, T::class)
+
+    /**
+     * Updates a record in the database with the given object.
+     *
+     * After executing the `update` statement, a query is executed,
+     * and all the mutable properties are updated with the values returned by the query.
+     *
+     * The updated object is also updated in the cache.
+     *
+     * @param obj The object to update.
+     * @param kClass The class of the object to update.
+     */
+    fun <T : Table> updateK(obj: T, kClass: KClass<T>) {
+        updateUncachedK(obj, kClass)
+        cache.putK(obj, kClass)
     }
 
     /**
@@ -270,21 +308,60 @@ class RacoonManager(
      * @param obj The object to delete.
      * @return The [RacoonManager] instance.
      */
-    inline fun <reified T : Table> delete(obj: T) = deleteK(obj, T::class)
+    inline fun <reified T : Table> deleteUncached(obj: T) = deleteUncachedK(obj, T::class)
 
     /**
      * Deletes a record from the database with the given object.
+     *
+     * NOTE: using this method while using [findK] is extremely not recommended.
+     * Doing so will cause the cache to be outdated,
+     * and may result in a find operation returning an object that is not in the database.
+     * Use [deleteK] instead.
      *
      * @param obj The object to delete.
      * @param kClass The class of the object to delete.
      * @return The [RacoonManager] instance.
      * @throws IllegalArgumentException if the object has no property with the name 'id'.
      */
-    fun <T : Table> deleteK(obj: T, kClass: KClass<T>) = apply {
+    fun <T : Table> deleteUncachedK(obj: T, kClass: KClass<T>) = apply {
         val id = obj.id ?: throw IllegalArgumentException("Can't delete object without id")
 
         createExecuteRacoon(generateDeleteQueryK(kClass)).use { executeRacoon ->
             executeRacoon.setParam("id", id).execute()
+        }
+    }
+
+    /**
+     * Behaves like [deleteK], but instead of passing the class as a normal parameter, it is passed as a reified type.
+     *
+     * @param T The type that is being deleted.
+     * @param obj The object to delete.
+     */
+    inline fun <reified T : Table> delete(obj: T) = deleteK(obj, T::class)
+
+    /**
+     * Deletes a record from the database with the given object.
+     *
+     * The deleted object is also deleted from the cache.
+     *
+     * @param obj The object to delete.
+     * @param kClass The class of the object to delete.
+     */
+    fun <T : Table> deleteK(obj: T, kClass: KClass<T>) {
+        deleteUncachedK(obj, kClass)
+        cache.removeK(obj.id!!, kClass)
+    }
+
+    inline fun <reified T : Table> refresh(obj: T) = refreshK(obj, T::class)
+
+    fun <T : Table> refreshK(obj: T, kClass: KClass<T>) = obj.apply {
+        val id = this.id ?: throw IllegalArgumentException("Can't refresh object without id")
+        val updated = findUncachedK(id, kClass) ?: throw SQLException("Could not find object with id '$id' " +
+                "while refreshing the fields")
+
+        for (parameter in kClass.memberProperties) {
+            if (parameter !is KMutableProperty<*>) continue
+            parameter.setter.call(this, getValueK(updated, parameter.name, kClass))
         }
     }
 

--- a/src/main/kotlin/habitat/cache/RacoonCache.kt
+++ b/src/main/kotlin/habitat/cache/RacoonCache.kt
@@ -1,0 +1,36 @@
+package habitat.cache
+
+import habitat.definition.Table
+import kotlin.reflect.KClass
+
+class RacoonCache {
+    private val cache: MutableMap<KClass<out Table>, MutableMap<Int, Table?>> = mutableMapOf()
+
+    inline fun <reified T : Table> get(id: Int) = getK(id, T::class)
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Table> getK(id: Int, kClass: KClass<T>): T? {
+        val tableCache = cache[kClass] ?: mutableMapOf<Int, Table?>().apply { cache[kClass] = this }
+
+        return tableCache[id]?.let { it as T }
+    }
+
+    inline fun <reified T : Table> put(table: T) = putK(table, T::class)
+
+    fun <T : Table> putK(table: T, kClass: KClass<T>) {
+        val tableCache = cache[kClass] ?: mutableMapOf<Int, Table?>().apply { cache[kClass] = this }
+
+        tableCache[table.id ?: throw IllegalArgumentException("Cannot cache entity without id")] = table
+    }
+
+    inline fun <reified T : Table> remove(id: Int) = removeK(id, T::class)
+
+    fun <T : Table> removeK(id: Int, kClass: KClass<T>) {
+        val tableCache = cache[kClass] ?: return
+        tableCache.remove(id)
+    }
+
+    fun clean() {
+        cache.clear()
+    }
+}

--- a/src/main/kotlin/habitat/cache/RacoonCache.kt
+++ b/src/main/kotlin/habitat/cache/RacoonCache.kt
@@ -1,26 +1,50 @@
 package habitat.cache
 
+import habitat.configuration.RacoonConfiguration
 import habitat.definition.Table
+import kotlin.math.min
 import kotlin.reflect.KClass
 
 class RacoonCache {
-    private val cache: MutableMap<KClass<out Table>, MutableMap<Int, Table?>> = mutableMapOf()
+    internal var cacheSize: Int = 0
+    internal val cache: MutableMap<KClass<out Table>, MutableMap<Int, Pair<Table?, Long>>> = mutableMapOf()
 
     inline fun <reified T : Table> get(id: Int) = getK(id, T::class)
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Table> getK(id: Int, kClass: KClass<T>): T? {
-        val tableCache = cache[kClass] ?: mutableMapOf<Int, Table?>().apply { cache[kClass] = this }
-
-        return tableCache[id]?.let { it as T }
+        return cache[kClass]?.let { mainMap ->
+            mainMap[id]?.let {
+                val v = it.first as T
+                mainMap[id] = v to System.currentTimeMillis()
+                v
+            }
+        }
     }
 
     inline fun <reified T : Table> put(table: T) = putK(table, T::class)
 
     fun <T : Table> putK(table: T, kClass: KClass<T>) {
-        val tableCache = cache[kClass] ?: mutableMapOf<Int, Table?>().apply { cache[kClass] = this }
+        val id = table.id ?: throw IllegalArgumentException("Cannot cache an entity without id")
 
-        tableCache[table.id ?: throw IllegalArgumentException("Cannot cache entity without id")] = table
+        // Get the secondary map (might be null)
+        var tableCache = cache[kClass]
+
+        // Cleaning the cache if it's too big
+        if (
+            (tableCache == null || !tableCache.containsKey(id)) &&
+            cacheSize >= RacoonConfiguration.Caching.maxEntries
+        ) forceCleanStale()
+
+        // Checking if the cache is still too big
+        if (cacheSize < RacoonConfiguration.Caching.maxEntries) {
+            // Creating the secondary map if it doesn't exist
+            tableCache = tableCache ?: mutableMapOf<Int, Pair<Table?, Long>>().apply { cache[kClass] = this }
+            // Saving the entity in the cache
+            tableCache[id] = table to System.currentTimeMillis()
+            // Incrementing the cache size
+            cacheSize++
+        }
     }
 
     inline fun <reified T : Table> remove(id: Int) = removeK(id, T::class)
@@ -28,9 +52,30 @@ class RacoonCache {
     fun <T : Table> removeK(id: Int, kClass: KClass<T>) {
         val tableCache = cache[kClass] ?: return
         tableCache.remove(id)
+        cacheSize--
     }
 
     fun clean() {
         cache.clear()
+    }
+
+    fun forceCleanStale() {
+        // Create the association (table, id, timestamp) of all entries in the cache
+        cache.entries
+            .fold(mutableListOf<Triple<KClass<out Table>, Int, Long>>()) { acc, mainMap ->
+                acc.apply {
+                    addAll(mainMap.value.entries.map { (secondMapKey, secondMapValue) ->
+                        Triple(mainMap.key, secondMapKey, secondMapValue.second)
+                    })
+                }
+            }
+            // Sort the entries by timestamp
+            .sortedBy { it.third }
+            // Get the first N entries (the oldest ones)
+            .subList(0, min(RacoonConfiguration.Caching.maxEntries, cacheSize))
+            // Remove the entries from the cache
+            .forEach {
+                removeK(it.second, it.first)
+            }
     }
 }

--- a/src/main/kotlin/habitat/configuration/RacoonConfiguration.kt
+++ b/src/main/kotlin/habitat/configuration/RacoonConfiguration.kt
@@ -1,5 +1,6 @@
 package habitat.configuration
 
+import habitat.RacoonManager
 import habitat.definition.LazyId
 import internals.casting.ParameterCaster
 import internals.casting.builtin.DateCaster
@@ -28,6 +29,24 @@ object RacoonConfiguration {
             host = "localhost",
             database = "test"
         )
+    }
+
+    object Caching {
+        /**
+         * The maximum number of entries in the cache of each [RacoonManager].
+         *
+         * The default value is 100.
+         */
+        var maxEntries: Int = 100
+
+        /**
+         * The number of entries to remove from the cache when it is full.
+         *
+         * Note: the entries removed are the oldest ones.
+         *
+         * The default value is 20.
+         */
+        var cleaningBatchSize: Int = 20
     }
 
     /**

--- a/src/test/kotlin/habitat/cache/RacoonCacheTest.kt
+++ b/src/test/kotlin/habitat/cache/RacoonCacheTest.kt
@@ -1,0 +1,82 @@
+package habitat.cache
+
+import habitat.RacoonDen
+import habitat.configuration.RacoonConfiguration
+import internals.configuration.ConnectionSettings
+import internals.mappers.NameMapper
+import models.Cat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RacoonCacheTest {
+
+    @BeforeEach
+    fun setUp() {
+        RacoonConfiguration.Connection.connectionSettings =
+            ConnectionSettings(
+                host = "localhost",
+                port = 3306,
+                database = "racoon-ktor-sample",
+                username = "admin",
+                password = "admin",
+                idleTimeout = 300
+            )
+        RacoonConfiguration.Naming.tableNameMapper = NameMapper.lowerSnakeCase
+        RacoonConfiguration.Naming.tableAliasMapper = NameMapper.lowerSnakeCase
+        RacoonConfiguration.Caching.maxEntries = 1
+    }
+
+    @Test
+    fun repeatedFind() {
+        RacoonDen.getManager().use { rm ->
+            val cat = rm.createQueryRacoon("SELECT * FROM cat LIMIT 1")
+                .mapToClass<Cat>()
+                .first().id!!
+
+            val start = System.currentTimeMillis()
+            for (i in 0..2000) {
+                rm.find<Cat>(cat)
+            }
+            val end = System.currentTimeMillis()
+            assertTrue(end - start < 50, "The cache took too long to be used")
+        }
+    }
+
+    @Test
+    fun replaceInCacheFind() {
+        RacoonDen.getManager().use { rm ->
+            val cat1 = rm.createQueryRacoon("SELECT * FROM cat LIMIT 1")
+                .mapToClass<Cat>()
+                .first().id!!
+            val cat2 = rm.createQueryRacoon("SELECT * FROM cat LIMIT 1 OFFSET 1")
+                .mapToClass<Cat>()
+                .first().id!!
+
+            rm.find<Cat>(cat1)
+
+            assertEquals(1, rm.cache.cacheSize)
+            assertTrue(rm.cache.cache.containsKey(Cat::class))
+            assertTrue(rm.cache.cache[Cat::class]!!.containsKey(cat1))
+
+            rm.find<Cat>(cat2)
+
+            assertEquals(1, rm.cache.cacheSize)
+            assertTrue(rm.cache.cache.containsKey(Cat::class))
+            assertTrue(rm.cache.cache[Cat::class]!!.containsKey(cat2))
+        }
+    }
+
+    @Test
+    fun insertCache() {
+        RacoonDen.getManager().use { rm ->
+            val cat = Cat(name = "test", age = 10)
+            rm.insert(cat)
+
+            assertEquals(1, rm.cache.cacheSize)
+            assertTrue(rm.cache.cache.containsKey(Cat::class))
+            assertTrue(rm.cache.cache[Cat::class]!!.containsKey(cat.id!!))
+        }
+    }
+}


### PR DESCRIPTION
The basic RM functions (find, insert, update and delete) now have cached and uncached variants. The old methods (such
as `find` and `findK`) are now cached, and new methods (such as `findUncached` and `findKUncached`) are uncached.

The cache size can be configured in the `RacoonConfiguration` object.

A new method has been added: `refresh`.
It allows to refresh the cache of a given object by executing the `findUncached` method.